### PR TITLE
Unify released and unreleased URLs to avoid stale links

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -319,7 +319,7 @@ type: docs
 
 ## Rust Versions
 
-- Stable: [{stable_version}](/docs/released/{stable_version})
+- Stable: [{stable_version}](/docs/release/{stable_version})
 "
     );
 
@@ -329,7 +329,7 @@ type: docs
         let days_left_text = pluralizer::pluralize("day", days_left as isize, true);
 
         index.push_str(&format!(
-            "- Beta: [{beta_version}](/docs/unreleased/{beta_version}) ({}, {} left)\n"
+            "- Beta: [{beta_version}](/docs/release/{beta_version}) ({}, {} left)\n"
             , release_date.release_date.format("%-d %B, %C%y"),
             days_left_text,
         ));
@@ -340,7 +340,7 @@ type: docs
         let days_left_text = pluralizer::pluralize("day", days_left as isize, true);
 
         index.push_str(&format!(
-            "- Nightly: [{nightly_version}](/docs/unreleased/{nightly_version}) ({}, {} left)\n"
+            "- Nightly: [{nightly_version}](/docs/release/{nightly_version}) ({}, {} left)\n"
             , release_date.release_date.format("%-d %B, %C%y"),
             days_left_text
         ));


### PR DESCRIPTION
Hello, I'm a huge fan of this site and it's my favorite way to stay up to date about practical upcoming changes that are coming to the language in a concrete timeframe.

Sometimes I like to share URLs from this page, but when I return to them later on, I get a 404 and need to change the URL from `unreleased` to `released`. 

I don't know if my proposed change actually fixes this in an acceptable way, because it panics in at least two ways when I run it (even without changes), but if this is acceptable it might be nice to have stable release URLs over time.
