### PR TITLE
CI: Update checkout and rust-cache actions

### DIFF
--- a/.github/workflows/periodic-build.yaml
+++ b/.github/workflows/periodic-build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
      
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Updates the used actions in the CI workflow to their latest versions.