### PR TITLE
Enable automatic dark/light mode

### DIFF
--- a/hugo/rust-changelogs/config.toml
+++ b/hugo/rust-changelogs/config.toml
@@ -5,3 +5,4 @@ googleAnalytics = 'G-WXS0HSEV58'
 
 [params]
 BookLogo = 'https://www.rust-lang.org/static/images/rust-logo-blk.svg'
+BookTheme = 'auto'


### PR DESCRIPTION
The `hugo-book` has a dark mode. This PR just enables it to automatically switch between dark/light based on user's preference