### PR TITLE
Fix sidebar order (Fixes #5 and #8)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,14 @@ fn remove_dir_contents<P: AsRef<Path>>(path: P) -> io::Result<()> {
     Ok(())
 }
 
+// Determines the order of releases in the side bar
+const fn determine_weight(Version { major, minor, patch, .. }: &Version) -> u32 {
+    u32::MAX
+        - ( ( *major as u32 ) << 24 )
+        - ( ( *minor as u32 ) << 8 )
+        - *patch as u32
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = fs::remove_dir_all("hugo/rust-changelogs/content");
@@ -103,7 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let content = format!(
             "---\nweight: {}\n---\n\n{} ({})\n========\n\n{}",
-            1000000 - version.minor,
+            determine_weight(version),
             version,
             release_date.format("%-d %B, %C%y"),
             trimmed
@@ -264,7 +272,7 @@ weight: {}
 {{{{< /hint >}}}}
 
 ",
-            1000000 - unreleased_version.minor,
+            determine_weight(unreleased_version),
             unreleased_version,
             release_name,
             if Utc::now().naive_utc().date() > release_date.branch_date { ", branched from master" } else { "" },


### PR DESCRIPTION
Previously, versions in the sidebar would be reverse-ordered by patch number. This commit fixes that  

Fixes:  
https://github.com/glebpom/rust-changelogs/issues/5
https://github.com/glebpom/rust-changelogs/issues/8