### PR TITLE
Correct phrasing of branch time box

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -247,29 +247,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ""
         };
         let release_date = calculate_release_date((unreleased_version.minor - stable_version.minor) as u32);
+        let already_branched = Utc::now().naive_utc().date() > release_date.branch_date;
         let mut changelog = format!(
             "---
-weight: {}
+weight: {weight}
 
 ---
 
-{} {}
+{version} {name}
 =========
 
 {{{{< hint warning >}}}}
-**Unreleased{}**
+**Unreleased{release_sfx}**
 
-- Will be stable on: _{}_
-- Will branch from master on: _{}_
+- Will be stable on: _{stable_date}_
+- {branch_pfx} from master on: _{branch_date}_
 {{{{< /hint >}}}}
 
 ",
-            1000000 - unreleased_version.minor,
-            unreleased_version,
-            release_name,
-            if Utc::now().naive_utc().date() > release_date.branch_date { ", branched from master" } else { "" },
-            release_date.release_date.format("%-d %B, %C%y"),
-            release_date.branch_date.format("%-d %B, %C%y"),
+            weight=1000000 - unreleased_version.minor,
+            version=unreleased_version,
+            name=release_name,
+            release_sfx= if already_branched { ", branched from master" } else { "" },
+            stable_date=release_date.release_date.format("%-d %B, %C%y"),
+            branch_pfx = if already_branched { "Branched" } else { "Will branch" },
+            branch_date=release_date.branch_date.format("%-d %B, %C%y"),
         );
         let mut issues_page = octocrab
             .issues("rust-lang", "rust")


### PR DESCRIPTION
The `will branch from master` part tends to throw me off when the date has already passed, such as now

![image](https://github.com/glebpom/rust-changelogs/assets/13724985/c3a3a64f-751a-406a-8080-73f25f65282f)

This should fix that. Also switched to named format params for easier understanding