### PR TITLE
Improve run time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Gleb Pomykalov <glebpom@gmail.com>"]
 
 [dependencies]
 octocrab = "0.28.0"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt", "macros"] }
 reqwest = { version = "0.11", features = ["trust-dns", "rustls"] }
 semver = "1"
 regex = "1"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cd rust-changelogs
 cargo run
 ```
 
-This will take a while, but when done you will have your generated pages in `hugo/rust-changelogs/public`.
+When done you will have your generated pages in `hugo/rust-changelogs/public`.
 
 ### Serving Locally
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,21 +190,14 @@ weight: {weight}
 
     let mut stabilization_prs = HashMap::new();
 
-    for search_term in [
-        "stabilise",
-        "Stabilise",
-        "Stabilize",
-        "stabilize",
-        "stabilisation",
-        "Stabilisation",
-        "Stabilization",
-        "stabilization",
-    ] {
+    for search_term in ["stabilise", "stabilize", "stabilisation", "stabilization"] {
         println!("search for {search_term} PRs");
 
         let mut prs_page = octocrab::instance()
             .search()
-            .issues_and_pull_requests(&format!("is:pr is:open repo:rust-lang/rust {search_term}"))
+            .issues_and_pull_requests(&format!(
+                "is:pr is:open in:title repo:rust-lang/rust {search_term}"
+            ))
             .sort("created_at")
             .order("desc")
             .send()
@@ -212,11 +205,9 @@ weight: {weight}
 
         loop {
             for pr in &prs_page {
-                if pr.title.starts_with(search_term)
-                    || pr
-                        .title
-                        .to_lowercase()
-                        .starts_with(&format!("partial {search_term}"))
+                let title = pr.title.to_lowercase();
+                if title.starts_with(search_term)
+                    || title.starts_with(&format!("partial {search_term}"))
                 {
                     stabilization_prs.insert(pr.id, pr.clone());
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 use chrono::{Duration, NaiveDate, Utc};
 use fs_extra::dir::CopyOptions;
 use itertools::Itertools;


### PR DESCRIPTION
This PR decreases the run time of looking up stabilization PRs by:
 1) Not unnecessarily searching for terms with different capitalization, when GitHub's search is already case-insensitive by default
 2) Limiting search to titles, so we don't have as many pages to search
 
 This decreases the total run time from about ~10 minutes to under 10 seconds on my machine (YMMV)
 
 I did check the output and it looks the same as the current state of releases.rs