### PR TITLE
Show info block instead of warning block on released versions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ weight: {weight}
 {version}
 =========
 
-{{{{< hint warning >}}}}
+{{{{< hint info >}}}}
 - Released on: _{release_date}_
 {version_branch_info_str}
 {{{{< /hint >}}}}


### PR DESCRIPTION
Old:
![image](https://github.com/glebpom/rust-changelogs/assets/11879454/c64def36-4cfa-41c1-88e7-4ab58a9b5600)

New:
![image](https://github.com/glebpom/rust-changelogs/assets/11879454/bcdd1355-2821-42c9-8f30-4c98b5020088)

The warning block still displays for beta and nightly